### PR TITLE
Feat/did manager add key sign only

### DIFF
--- a/packages/core-types/src/plugin.schema.ts
+++ b/packages/core-types/src/plugin.schema.ts
@@ -1070,14 +1070,18 @@ export const schema = {
             },
             "options": {
               "type": "object",
+              "properties": {
+                "signOnly": {
+                  "type": "boolean"
+                }
+              },
               "description": "Optional. Identifier provider specific options"
             }
           },
           "required": [
             "did",
             "key"
-          ],
-          "description": "Input arguments for  {@link IDIDManager.didManagerAddKey | didManagerAddKey }"
+          ]
         },
         "IKey": {
           "type": "object",

--- a/packages/core-types/src/types/IDIDManager.ts
+++ b/packages/core-types/src/types/IDIDManager.ts
@@ -153,7 +153,20 @@ export interface IDIDManagerUpdateArgs {
   }
 }
 
-/**
+type TxnParams = [
+  attrName: string,
+  attrValue: string,
+  ttl: number,
+  signature: { sigV: number; sigR: string; sigS: string },
+  options: Record<string, any>,
+]
+
+export interface IDIDManagerSubmitTransactionArgs {
+  txnParams: TxnParams,
+  provider: string,
+}
+
+/*
  * Input arguments for {@link IDIDManager.didManagerAddKey | didManagerAddKey}
  * @public
  */

--- a/packages/core-types/src/types/IDIDManager.ts
+++ b/packages/core-types/src/types/IDIDManager.ts
@@ -171,7 +171,7 @@ export interface IDIDManagerAddKeyArgs {
   /**
    * Optional. Identifier provider specific options
    */
-  options?: object
+  options?: Record<string, any> & { signOnly?: boolean }
 }
 
 /**

--- a/packages/core-types/src/types/IDIDManager.ts
+++ b/packages/core-types/src/types/IDIDManager.ts
@@ -162,8 +162,9 @@ type TxnParams = [
 ]
 
 export interface IDIDManagerSubmitTransactionArgs {
-  txnParams: TxnParams,
-  provider: string,
+  txnParams: TxnParams
+  provider: string
+  did: string
 }
 
 /*

--- a/packages/core-types/src/types/IDIDManager.ts
+++ b/packages/core-types/src/types/IDIDManager.ts
@@ -164,7 +164,8 @@ type TxnParams = [
 export interface IDIDManagerSubmitTransactionArgs {
   txnParams: TxnParams
   provider: string
-  did: string
+  principalDid: string
+  agentDid: string
 }
 
 /*

--- a/packages/did-manager/src/abstract-identifier-provider.ts
+++ b/packages/did-manager/src/abstract-identifier-provider.ts
@@ -24,6 +24,7 @@ export abstract class AbstractIdentifierProvider {
 
   abstract submitTransaction(
     args: {
+      identifier: IIdentifier
       txnParams: [
         attrName: string,
         attrValue: string,

--- a/packages/did-manager/src/abstract-identifier-provider.ts
+++ b/packages/did-manager/src/abstract-identifier-provider.ts
@@ -22,6 +22,20 @@ export abstract class AbstractIdentifierProvider {
     context: IAgentContext<IKeyManager>,
   ): Promise<any>
 
+  abstract submitTransaction(
+    args: {
+      txnParams: [
+        attrName: string,
+        attrValue: string,
+        ttl: number,
+        signature: { sigV: number; sigR: string; sigS: string },
+        options: Record<string, any>,
+      ]
+      provider: string
+    },
+    context: IAgentContext<IKeyManager>,
+  ): Promise<any>
+
   abstract removeKey(
     args: { identifier: IIdentifier; kid: string; options?: any },
     context: IAgentContext<IKeyManager>,

--- a/packages/did-manager/src/abstract-identifier-provider.ts
+++ b/packages/did-manager/src/abstract-identifier-provider.ts
@@ -33,6 +33,7 @@ export abstract class AbstractIdentifierProvider {
         options: Record<string, any>,
       ]
       provider: string
+      principalDid?: string
     },
     context: IAgentContext<IKeyManager>,
   ): Promise<any>

--- a/packages/did-manager/src/abstract-identifier-provider.ts
+++ b/packages/did-manager/src/abstract-identifier-provider.ts
@@ -11,14 +11,14 @@ export abstract class AbstractIdentifierProvider {
   ): Promise<Omit<IIdentifier, 'provider'>>
 
   abstract updateIdentifier?(
-    args: { did: string, document: Partial<DIDDocument>, options?: { [x: string]: any } },
+    args: { did: string; document: Partial<DIDDocument>; options?: { [x: string]: any } },
     context: IAgentContext<IKeyManager>,
   ): Promise<IIdentifier>
 
   abstract deleteIdentifier(args: IIdentifier, context: IAgentContext<IKeyManager>): Promise<boolean>
 
   abstract addKey(
-    args: { identifier: IIdentifier; key: IKey; options?: any },
+    args: { identifier: IIdentifier; key: IKey; options?: Record<string, any> & { signOnly?: boolean } },
     context: IAgentContext<IKeyManager>,
   ): Promise<any>
 

--- a/packages/did-manager/src/id-manager.ts
+++ b/packages/did-manager/src/id-manager.ts
@@ -219,10 +219,11 @@ export class DIDManager implements IAgentPlugin {
 
   /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerSubmitTxn} */
   async didManagerSubmitTxn(
-    { txnParams, provider }: IDIDManagerSubmitTransactionArgs,
+    { txnParams, provider, did }: IDIDManagerSubmitTransactionArgs,
     context: IAgentContext<IKeyManager>,
   ): Promise<any> {
-    return this.getProvider(provider).submitTransaction({ txnParams, provider }, context)
+    const identifier = await this.store.getDID({ did })
+    return this.getProvider(provider).submitTransaction({ identifier, txnParams, provider }, context)
   }
 
   /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerAddKey} */

--- a/packages/did-manager/src/id-manager.ts
+++ b/packages/did-manager/src/id-manager.ts
@@ -20,6 +20,7 @@ import {
   MinimalImportableIdentifier,
   IKey,
   IService,
+  IDIDManagerSubmitTransactionArgs,
 } from '@veramo/core-types'
 import { schema } from '@veramo/core-types'
 import { AbstractDIDStore } from './abstract-identifier-store.js'
@@ -214,6 +215,14 @@ export class DIDManager implements IAgentPlugin {
     const provider = this.getProvider(identifier.provider)
     await provider.deleteIdentifier(identifier, context)
     return this.store.deleteDID({ did })
+  }
+
+  /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerSubmitTxn} */
+  async didManagerSubmitTxn(
+    { txnParams, provider }: IDIDManagerSubmitTransactionArgs,
+    context: IAgentContext<IKeyManager>,
+  ): Promise<any> {
+    return this.getProvider(provider).submitTransaction({ txnParams, provider }, context)
   }
 
   /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerAddKey} */

--- a/packages/did-manager/src/id-manager.ts
+++ b/packages/did-manager/src/id-manager.ts
@@ -220,11 +220,14 @@ export class DIDManager implements IAgentPlugin {
 
   /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerSubmitTxn} */
   async didManagerSubmitTxn(
-    { txnParams, provider, did }: IDIDManagerSubmitTransactionArgs,
+    { txnParams, provider, agentDid, principalDid }: IDIDManagerSubmitTransactionArgs,
     context: IAgentContext<IKeyManager>,
   ): Promise<any> {
-    const identifier = await this.store.getDID({ did })
-    return this.getProvider(provider).submitTransaction({ identifier, txnParams, provider }, context)
+    const identifier = await this.store.getDID({ did: agentDid })
+    return this.getProvider(provider).submitTransaction(
+      { identifier, txnParams, provider, principalDid },
+      context,
+    )
   }
 
   /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerAddKey} */

--- a/packages/did-manager/src/id-manager.ts
+++ b/packages/did-manager/src/id-manager.ts
@@ -61,6 +61,7 @@ export class DIDManager implements IAgentPlugin {
       didManagerImport: this.didManagerImport.bind(this),
       didManagerDelete: this.didManagerDelete.bind(this),
       didManagerAddKey: this.didManagerAddKey.bind(this),
+      didManagerSubmitTxn: this.didManagerSubmitTxn.bind(this),
       didManagerRemoveKey: this.didManagerRemoveKey.bind(this),
       didManagerAddService: this.didManagerAddService.bind(this),
       didManagerRemoveService: this.didManagerRemoveService.bind(this),

--- a/packages/did-provider-ethr/src/ethr-did-provider.ts
+++ b/packages/did-provider-ethr/src/ethr-did-provider.ts
@@ -458,7 +458,21 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
 
     debug('ethrDid.setAttribute %o', { attrName, attrValue, ttl, gasLimit })
 
-    if (options?.metaIdentifierKeyId) {
+    if (options?.signOnly) {
+      const metaHash = await ethrDid.createSetAttributeHash(attrName, attrValue, ttl)
+      const canonicalSignature = await EthrDIDProvider.createMetaSignature(context, identifier, metaHash)
+      debug('ethrDid.addServiceSigned %o', { attrName, attrValue, ttl, gasLimit })
+      delete options.metaIdentifierKeyId
+      const txnParams: AddTxnParams = [
+        attrName,
+        attrValue,
+        ttl,
+        { sigV: canonicalSignature.v, sigR: canonicalSignature.r, sigS: canonicalSignature.s },
+        { ...options, gasLimit },
+      ]
+      debug('ethrDid.addServiceSigned: signing only. Returning TransactionParams')
+      return txnParams
+    } else if (options?.metaIdentifierKeyId) {
       const metaHash = await ethrDid.createSetAttributeHash(attrName, attrValue, ttl)
       const canonicalSignature = await EthrDIDProvider.createMetaSignature(context, identifier, metaHash)
 
@@ -472,7 +486,6 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
         { sigV: canonicalSignature.v, sigR: canonicalSignature.r, sigS: canonicalSignature.s },
         { ...options, gasLimit },
       ]
-      if (options.signOnly) return txnParams
       const txHash = await metaEthrDid.setAttributeSigned(...txnParams)
       debug(`ethrDid.addServiceSigned tx = ${txHash}`)
       return txHash
@@ -501,7 +514,19 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
     const attrValue = '0x' + key.publicKeyHex
     const gasLimit = args.options?.gasLimit || this.gas || DEFAULT_GAS_LIMIT
 
-    if (args.options?.metaIdentifierKeyId) {
+    if (args.options?.signOnly) {
+      const metaHash = await ethrDid.createRevokeAttributeHash(attrName, attrValue)
+      const canonicalSignature = await EthrDIDProvider.createMetaSignature(context, args.identifier, metaHash)
+      debug('ethrDid.revokeAttributeSigned %o', { attrName, attrValue, gasLimit })
+      const txnParams: RemoveTxnParams = [
+        attrName,
+        attrValue,
+        { sigV: canonicalSignature.v, sigR: canonicalSignature.r, sigS: canonicalSignature.s },
+        { ...args.options, gasLimit },
+      ]
+      debug('ethrDid.revokeAttributeSigned: signing only. Returning TransactionParams')
+      return txnParams
+    } else if (args.options?.metaIdentifierKeyId) {
       const metaHash = await ethrDid.createRevokeAttributeHash(attrName, attrValue)
       const canonicalSignature = await EthrDIDProvider.createMetaSignature(context, args.identifier, metaHash)
 
@@ -548,7 +573,19 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
         : JSON.stringify(service.serviceEndpoint)
     const gasLimit = args.options?.gasLimit || this.gas || DEFAULT_GAS_LIMIT
 
-    if (args.options?.metaIdentifierKeyId) {
+    if (args.options?.signOnly) {
+      const metaHash = await ethrDid.createRevokeAttributeHash(attrName, attrValue)
+      const canonicalSignature = await EthrDIDProvider.createMetaSignature(context, args.identifier, metaHash)
+      debug('ethrDid.revokeAttributeSigned %o', { attrName, attrValue, gasLimit })
+      const txnParams: RemoveTxnParams = [
+        attrName,
+        attrValue,
+        { sigV: canonicalSignature.v, sigR: canonicalSignature.r, sigS: canonicalSignature.s },
+        { ...args.options, gasLimit },
+      ]
+      debug('ethrDid.revokeAttributeSigned: signing only. Returning TransactionParams')
+      return txnParams
+    } else if (args.options?.metaIdentifierKeyId) {
       const metaHash = await ethrDid.createRevokeAttributeHash(attrName, attrValue)
       const canonicalSignature = await EthrDIDProvider.createMetaSignature(context, args.identifier, metaHash)
 

--- a/packages/did-provider-ethr/src/ethr-did-provider.ts
+++ b/packages/did-provider-ethr/src/ethr-did-provider.ts
@@ -353,6 +353,7 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
       ]
 
       if (options.signOnly) return txnParams
+
       const txHash = await metaEthrDid.setAttributeSigned(...txnParams)
       debug(`ethrDid.addKeySigned tx = ${txHash}`)
       return txHash

--- a/packages/did-provider-ethr/src/ethr-did-provider.ts
+++ b/packages/did-provider-ethr/src/ethr-did-provider.ts
@@ -356,6 +356,10 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
     }
   }
 
+  /**
+   * @remarks This method submits transactions signed in Add/Remove Key/Service methods that
+   * have been prepared with the signOnly option flag.
+   **/
   async submitTransaction(
     {
       txnParams,

--- a/packages/did-provider-ethr/src/ethr-did-provider.ts
+++ b/packages/did-provider-ethr/src/ethr-did-provider.ts
@@ -327,6 +327,15 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
     }
   }
 
+  async submitTransaction(
+    { txnParams, identifier }: { identifier: IIdentifier; txnParams: TxnParams },
+    context: IRequiredContext,
+  ): Promise<any> {
+    const metaEthrDid = await this.getEthrDidController(identifier, context)
+    const txHash = await metaEthrDid.setAttributeSigned(...txnParams)
+    return txHash
+  }
+
   async addKey(
     { identifier, key, options }: { identifier: IIdentifier; key: IKey; options?: TransactionOptions },
     context: IRequiredContext,

--- a/packages/did-provider-ethr/src/ethr-did-provider.ts
+++ b/packages/did-provider-ethr/src/ethr-did-provider.ts
@@ -282,9 +282,6 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
     console.log('network', network)
     const metaControllerKey = await context.agent.keyManagerGet({ kid: metaIdentifierKeyId })
     if (!network || !metaControllerKey) throw new Error(`invalid_argument: controller key or network error`)
-    /**
-     * TODO: make the did chainId/name consistent across the snap and the tspn
-     **/
     return new EthrDID({
       identifier: principalDid,
       provider: network.provider,

--- a/packages/did-provider-ethr/src/ethr-did-provider.ts
+++ b/packages/did-provider-ethr/src/ethr-did-provider.ts
@@ -279,8 +279,12 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
     const networkStringMatcher = /^did:ethr(:.+)?:(0x[0-9a-fA-F]{40}|0x[0-9a-fA-F]{66}).*$/
     const matches = identifier.did.match(networkStringMatcher)
     const network = this.getNetworkFor(matches?.[1]?.substring(1))
+    console.log('network', network)
     const metaControllerKey = await context.agent.keyManagerGet({ kid: metaIdentifierKeyId })
     if (!network || !metaControllerKey) throw new Error(`invalid_argument: controller key or network error`)
+    /**
+     * TODO: make the did chainId/name consistent across the snap and the tspn
+     **/
     return new EthrDID({
       identifier: principalDid,
       provider: network.provider,

--- a/packages/did-provider-ion/src/ion-did-provider.ts
+++ b/packages/did-provider-ion/src/ion-did-provider.ts
@@ -174,6 +174,23 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     return true
   }
 
+  async submitTransaction(
+    args: {
+      identifier: IIdentifier
+      txnParams: [
+        attrName: string,
+        attrValue: string,
+        ttl: number,
+        signature: { sigV: number; sigR: string; sigS: string },
+        options: Record<string, any>,
+      ]
+      provider: string
+    },
+    context: IContext,
+  ): Promise<any> {
+    throw new Error('not_supported: IonDIDProvider submitTransaction not supported yet.')
+  }
+
   /** {@inheritDoc @veramo/core-types#IDIDManager.didManagerAddKey} */
   async addKey(
     { identifier, key, options }: { identifier: IIdentifier; key: IKey; options?: IAddKeyOpts },

--- a/packages/did-provider-ion/src/ion-did-provider.ts
+++ b/packages/did-provider-ion/src/ion-did-provider.ts
@@ -175,10 +175,10 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
   }
 
   /**
-   * @remarks This method has not yet been implemented for PeerDIDProvider
+   * @remarks This method has not yet been implemented for IonDIDProvider
    **/
   async submitTransaction(
-    args: {
+    _args: {
       identifier: IIdentifier
       txnParams: [
         attrName: string,
@@ -189,7 +189,7 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
       ]
       provider: string
     },
-    context: IContext,
+    _context: IContext,
   ): Promise<any> {
     throw new Error('not_supported: IonDIDProvider submitTransaction not supported yet.')
   }

--- a/packages/did-provider-ion/src/ion-did-provider.ts
+++ b/packages/did-provider-ion/src/ion-did-provider.ts
@@ -174,6 +174,9 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     return true
   }
 
+  /**
+   * @remarks This method has not yet been implemented for PeerDIDProvider
+   **/
   async submitTransaction(
     args: {
       identifier: IIdentifier

--- a/packages/did-provider-ion/src/ion-did-provider.ts
+++ b/packages/did-provider-ion/src/ion-did-provider.ts
@@ -443,8 +443,8 @@ export class IonDIDProvider extends AbstractIdentifierProvider {
     const type = options?.type
       ? options.type
       : options?.key?.type
-      ? (options.key.type as KeyType)
-      : KeyType.Secp256k1
+        ? (options.key.type as KeyType)
+        : KeyType.Secp256k1
 
     const meta = options?.key?.meta ? options.key.meta : {}
     const ionMeta: IonKeyMetadata = {

--- a/packages/did-provider-jwk/src/jwk-did-provider.ts
+++ b/packages/did-provider-jwk/src/jwk-did-provider.ts
@@ -76,6 +76,23 @@ export class JwkDIDProvider extends AbstractIdentifierProvider {
     return true
   }
 
+  async submitTransaction(
+    args: {
+      identifier: IIdentifier
+      txnParams: [
+        attrName: string,
+        attrValue: string,
+        ttl: number,
+        signature: { sigV: number; sigR: string; sigS: string },
+        options: Record<string, any>,
+      ]
+      provider: string
+    },
+    context: IContext,
+  ): Promise<any> {
+    throw new Error('not_supported: JwkDIDProvider submitTransaction not possible')
+  }
+
   async addKey(
     { identifier, key, options }: { identifier: IIdentifier; key: IKey; options?: any },
     context: IContext,
@@ -118,3 +135,4 @@ export class JwkDIDProvider extends AbstractIdentifierProvider {
     })
   }
 }
+

--- a/packages/did-provider-jwk/src/jwk-did-provider.ts
+++ b/packages/did-provider-jwk/src/jwk-did-provider.ts
@@ -76,8 +76,11 @@ export class JwkDIDProvider extends AbstractIdentifierProvider {
     return true
   }
 
+  /**
+   * @remarks This method has not yet been implemented for JwkDIDProvider
+   **/
   async submitTransaction(
-    args: {
+    _args: {
       identifier: IIdentifier
       txnParams: [
         attrName: string,
@@ -88,7 +91,7 @@ export class JwkDIDProvider extends AbstractIdentifierProvider {
       ]
       provider: string
     },
-    context: IContext,
+    _context: IContext,
   ): Promise<any> {
     throw new Error('not_supported: JwkDIDProvider submitTransaction not possible')
   }

--- a/packages/did-provider-key/src/key-did-provider.ts
+++ b/packages/did-provider-key/src/key-did-provider.ts
@@ -48,8 +48,13 @@ export class KeyDIDProvider extends AbstractIdentifierProvider {
       context,
     )
 
-    const publicKeyHex = key.type === 'Secp256k1' ? SigningKey.computePublicKey('0x' + key.publicKeyHex, true) : key.publicKeyHex
-    const methodSpecificId: string = bytesToMultibase(hexToBytes(publicKeyHex), 'base58btc', keyCodecs[keyType])
+    const publicKeyHex =
+      key.type === 'Secp256k1' ? SigningKey.computePublicKey('0x' + key.publicKeyHex, true) : key.publicKeyHex
+    const methodSpecificId: string = bytesToMultibase(
+      hexToBytes(publicKeyHex),
+      'base58btc',
+      keyCodecs[keyType],
+    )
 
     const identifier: Omit<IIdentifier, 'provider'> = {
       did: 'did:key:' + methodSpecificId,
@@ -78,6 +83,23 @@ export class KeyDIDProvider extends AbstractIdentifierProvider {
       await context.agent.keyManagerDelete({ kid })
     }
     return true
+  }
+
+  async submitTransaction(
+    args: {
+      identifier: IIdentifier
+      txnParams: [
+        attrName: string,
+        attrValue: string,
+        ttl: number,
+        signature: { sigV: number; sigR: string; sigS: string },
+        options: Record<string, any>,
+      ]
+      provider: string
+    },
+    _context: IContext,
+  ): Promise<any> {
+    throw Error('KeyDIDProvider submitTransaction not supported')
   }
 
   async addKey(

--- a/packages/did-provider-key/src/key-did-provider.ts
+++ b/packages/did-provider-key/src/key-did-provider.ts
@@ -85,8 +85,11 @@ export class KeyDIDProvider extends AbstractIdentifierProvider {
     return true
   }
 
+  /**
+   * @remarks This method has not yet been implemented for KeyDIDProvider
+   **/
   async submitTransaction(
-    args: {
+    _args: {
       identifier: IIdentifier
       txnParams: [
         attrName: string,

--- a/packages/did-provider-peer/src/peer-did-provider.ts
+++ b/packages/did-provider-peer/src/peer-did-provider.ts
@@ -128,8 +128,11 @@ export class PeerDIDProvider extends AbstractIdentifierProvider {
     }
   }
 
+  /**
+   * @remarks This method has not yet been implemented for PeerDIDProvider
+   **/
   async submitTransaction(
-    args: {
+    _args: {
       identifier: IIdentifier
       txnParams: [
         attrName: string,
@@ -140,7 +143,7 @@ export class PeerDIDProvider extends AbstractIdentifierProvider {
       ]
       provider: string
     },
-    context: IAgentContext<IKeyManager>,
+    _context: IAgentContext<IKeyManager>,
   ): Promise<any> {
     throw new Error('not_supported: PeerDIDProvider submitTransaction not supported yet.')
   }

--- a/packages/did-provider-peer/src/peer-did-provider.ts
+++ b/packages/did-provider-peer/src/peer-did-provider.ts
@@ -128,6 +128,23 @@ export class PeerDIDProvider extends AbstractIdentifierProvider {
     }
   }
 
+  async submitTransaction(
+    args: {
+      identifier: IIdentifier
+      txnParams: [
+        attrName: string,
+        attrValue: string,
+        ttl: number,
+        signature: { sigV: number; sigR: string; sigS: string },
+        options: Record<string, any>,
+      ]
+      provider: string
+    },
+    context: IAgentContext<IKeyManager>,
+  ): Promise<any> {
+    throw new Error('not_supported: PeerDIDProvider submitTransaction not supported yet.')
+  }
+
   async updateIdentifier(
     args: { did: string; kms?: string | undefined; alias?: string | undefined; options?: any },
     context: IAgentContext<IKeyManager>,

--- a/packages/did-provider-pkh/src/pkh-did-provider.ts
+++ b/packages/did-provider-pkh/src/pkh-did-provider.ts
@@ -113,6 +113,9 @@ export class PkhDIDProvider extends AbstractIdentifierProvider {
     return true
   }
 
+  /**
+   * @remarks This method has not yet been implemented for PkhDIDProvider
+   **/
   async submitTransaction(
     {
       identifier,

--- a/packages/did-provider-pkh/src/pkh-did-provider.ts
+++ b/packages/did-provider-pkh/src/pkh-did-provider.ts
@@ -1,40 +1,33 @@
-import { computeAddress } from 'ethers';
-import {
-  IAgentContext,
-  IIdentifier,
-  IKey,
-  IKeyManager,
-  IService,
-  ManagedKeyInfo,
-} from '@veramo/core-types';
+import { computeAddress } from 'ethers'
+import { IAgentContext, IIdentifier, IKey, IKeyManager, IService, ManagedKeyInfo } from '@veramo/core-types'
 
-import { AbstractIdentifierProvider } from '@veramo/did-manager';
+import { AbstractIdentifierProvider } from '@veramo/did-manager'
 import Debug from 'debug'
 
 const debug = Debug('veramo:pkh-did-provider')
 
-type IContext = IAgentContext<IKeyManager>;
+type IContext = IAgentContext<IKeyManager>
 
 const isIn = <T>(values: readonly T[], value: any): value is T => {
-  return values.includes(value);
-};
+  return values.includes(value)
+}
 
-export const SECPK1_NAMESPACES = ['eip155'] as const;
-export const isValidNamespace = (x: string) => isIn(SECPK1_NAMESPACES, x);
+export const SECPK1_NAMESPACES = ['eip155'] as const
+export const isValidNamespace = (x: string) => isIn(SECPK1_NAMESPACES, x)
 
 /**
  * Options for creating a did:pkh
  * @beta
  */
 export interface CreateDidPkhOptions {
-  namespace: string;
-  privateKey: string;
+  namespace: string
+  privateKey: string
   /**
    * This can be hex encoded chain ID (string) or a chainId number
    *
    * If this is not specified, `1` is assumed.
    */
-  chainId?: string | number;
+  chainId?: string | number
 }
 
 /**
@@ -42,10 +35,8 @@ export interface CreateDidPkhOptions {
  * @param hexPublicKey A hex encoded public key, optionally prefixed with `0x`
  */
 export function toEthereumAddress(hexPublicKey: string): string {
-  const publicKey = hexPublicKey.startsWith('0x')
-    ? hexPublicKey
-    : '0x' + hexPublicKey;
-  return computeAddress(publicKey);
+  const publicKey = hexPublicKey.startsWith('0x') ? hexPublicKey : '0x' + hexPublicKey
+  return computeAddress(publicKey)
 }
 
 /**
@@ -54,44 +45,40 @@ export function toEthereumAddress(hexPublicKey: string): string {
  * @beta This API may change without a BREAKING CHANGE notice.
  */
 export class PkhDIDProvider extends AbstractIdentifierProvider {
-  private defaultKms: string;
-  private chainId: string;
+  private defaultKms: string
+  private chainId: string
 
   constructor(options: { defaultKms: string; chainId?: string }) {
-    super();
-    this.defaultKms = options.defaultKms;
-    this.chainId = options?.chainId ? options.chainId : '1';
+    super()
+    this.defaultKms = options.defaultKms
+    this.chainId = options?.chainId ? options.chainId : '1'
   }
 
   async createIdentifier(
     { kms, options }: { kms?: string; options?: CreateDidPkhOptions },
-    context: IContext
+    context: IContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const namespace = options?.namespace ? options.namespace : 'eip155';
+    const namespace = options?.namespace ? options.namespace : 'eip155'
 
     if (!isValidNamespace(namespace)) {
-      debug(
-        `invalid_namespace: '${namespace}'. valid namespaces are: ${SECPK1_NAMESPACES}`
-      );
-      throw new Error(
-        `invalid_namespace: '${namespace}'. valid namespaces are: ${SECPK1_NAMESPACES}`
-      );
+      debug(`invalid_namespace: '${namespace}'. valid namespaces are: ${SECPK1_NAMESPACES}`)
+      throw new Error(`invalid_namespace: '${namespace}'. valid namespaces are: ${SECPK1_NAMESPACES}`)
     }
 
-    let key: ManagedKeyInfo | null;
-    if (options?.privateKey !== undefined){
+    let key: ManagedKeyInfo | null
+    if (options?.privateKey !== undefined) {
       key = await context.agent.keyManagerImport({
         kms: kms || this.defaultKms,
         type: 'Secp256k1',
         privateKeyHex: options?.privateKey as string,
-      });
+      })
     } else {
-      key = await context.agent.keyManagerCreate({ 
-        kms: kms || this.defaultKms, 
-        type: 'Secp256k1' 
-      });
+      key = await context.agent.keyManagerCreate({
+        kms: kms || this.defaultKms,
+        type: 'Secp256k1',
+      })
     }
-    const evmAddress: string = toEthereumAddress(key.publicKeyHex);
+    const evmAddress: string = toEthereumAddress(key.publicKeyHex)
 
     if (key !== null) {
       const identifier: Omit<IIdentifier, 'provider'> = {
@@ -99,71 +86,79 @@ export class PkhDIDProvider extends AbstractIdentifierProvider {
         controllerKeyId: key.kid,
         keys: [key],
         services: [],
-      };
-      return identifier;
+      }
+      return identifier
     } else {
-      debug('Could not create identifier due to some errors');
-      throw new Error('unknown_error: could not create identifier due to errors creating or importing keys');
+      debug('Could not create identifier due to some errors')
+      throw new Error('unknown_error: could not create identifier due to errors creating or importing keys')
     }
   }
 
   async updateIdentifier(
     args: {
-      did: string;
-      kms?: string | undefined;
-      alias?: string | undefined;
-      options?: any;
+      did: string
+      kms?: string | undefined
+      alias?: string | undefined
+      options?: any
     },
-    context: IAgentContext<IKeyManager>
+    context: IAgentContext<IKeyManager>,
   ): Promise<IIdentifier> {
-    throw new Error('illegal_operation: did:pkh update is not possible.');
+    throw new Error('illegal_operation: did:pkh update is not possible.')
   }
 
-  async deleteIdentifier(
-    identifier: IIdentifier,
-    context: IContext
-  ): Promise<boolean> {
+  async deleteIdentifier(identifier: IIdentifier, context: IContext): Promise<boolean> {
     for (const { kid } of identifier.keys) {
-      await context.agent.keyManagerDelete({ kid });
+      await context.agent.keyManagerDelete({ kid })
     }
-    return true;
+    return true
+  }
+
+  async submitTransaction(
+    {
+      identifier,
+      txnParams,
+      provider,
+    }: {
+      identifier: IIdentifier
+      txnParams: [
+        attrName: string,
+        attrValue: string,
+        ttl: number,
+        signature: { sigV: number; sigR: string; sigS: string },
+        options: Record<string, any>,
+      ]
+      provider: string
+    },
+    context: IContext,
+  ): Promise<any> {
+    throw Error('illegal_operation: did:pkh submitTransaction is not possible.')
   }
 
   async addKey(
-    {
-      identifier,
-      key,
-      options,
-    }: { identifier: IIdentifier; key: IKey; options?: any },
-    context: IContext
+    { identifier, key, options }: { identifier: IIdentifier; key: IKey; options?: any },
+    context: IContext,
   ): Promise<any> {
-    throw Error('illegal_operation: did:pkh addKey is not possible.');
+    throw Error('illegal_operation: did:pkh addKey is not possible.')
   }
 
   async addService(
-    {
-      identifier,
-      service,
-      options,
-    }: { identifier: IIdentifier; service: IService; options?: any },
-    context: IContext
+    { identifier, service, options }: { identifier: IIdentifier; service: IService; options?: any },
+    context: IContext,
   ): Promise<any> {
-    throw Error('illegal_operation: did:pkh addService is not possible.');
+    throw Error('illegal_operation: did:pkh addService is not possible.')
   }
 
   async removeKey(
     args: { identifier: IIdentifier; kid: string; options?: any },
-    context: IContext
+    context: IContext,
   ): Promise<any> {
-    throw Error('illegal_operation: did:pkh removeKey is not possible.');
-
+    throw Error('illegal_operation: did:pkh removeKey is not possible.')
   }
 
   async removeService(
     args: { identifier: IIdentifier; id: string; options?: any },
-    context: IContext
+    context: IContext,
   ): Promise<any> {
-    throw Error('illegal_operation: did:pkh removeService is not possible.');
-
+    throw Error('illegal_operation: did:pkh removeService is not possible.')
   }
 }

--- a/packages/did-provider-web/src/web-did-provider.ts
+++ b/packages/did-provider-web/src/web-did-provider.ts
@@ -35,7 +35,10 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
     return identifier
   }
 
-  async updateIdentifier(args: { did: string; kms?: string | undefined; alias?: string | undefined; options?: any }, context: IAgentContext<IKeyManager>): Promise<IIdentifier> {
+  async updateIdentifier(
+    args: { did: string; kms?: string | undefined; alias?: string | undefined; options?: any },
+    context: IAgentContext<IKeyManager>,
+  ): Promise<IIdentifier> {
     throw new Error('WebDIDProvider updateIdentifier not supported yet.')
   }
 
@@ -44,6 +47,23 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
       await context.agent.keyManagerDelete({ kid })
     }
     return true
+  }
+
+  async submitTransaction(
+    args: {
+      identifier: IIdentifier
+      txnParams: [
+        attrName: string,
+        attrValue: string,
+        ttl: number,
+        signature: { sigV: number; sigR: string; sigS: string },
+        options: Record<string, any>,
+      ]
+      provider: string
+    },
+    context: IContext,
+  ): Promise<any> {
+    throw new Error('not_supported: WebDIDProvider submitTransaction not supported yet.')
   }
 
   async addKey(

--- a/packages/did-provider-web/src/web-did-provider.ts
+++ b/packages/did-provider-web/src/web-did-provider.ts
@@ -49,8 +49,11 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
     return true
   }
 
+  /**
+   * @remarks This method has not yet been implemented for WebDIDProvider
+   **/
   async submitTransaction(
-    args: {
+    _args: {
       identifier: IIdentifier
       txnParams: [
         attrName: string,
@@ -61,7 +64,7 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
       ]
       provider: string
     },
-    context: IContext,
+    _context: IContext,
   ): Promise<any> {
     throw new Error('not_supported: WebDIDProvider submitTransaction not supported yet.')
   }

--- a/packages/test-utils/src/example-did.ts
+++ b/packages/test-utils/src/example-did.ts
@@ -47,7 +47,10 @@ export class ExampleDidProvider extends AbstractIdentifierProvider {
     return identifier
   }
 
-  async updateIdentifier(args: { did: string; kms?: string | undefined; alias?: string | undefined; options?: any }, context: IAgentContext<IKeyManager>): Promise<IIdentifier> {
+  async updateIdentifier(
+    args: { did: string; kms?: string | undefined; alias?: string | undefined; options?: any },
+    context: IAgentContext<IKeyManager>,
+  ): Promise<IIdentifier> {
     throw new Error('FakeDIDProvider updateIdentifier not supported yet.')
   }
 
@@ -56,6 +59,23 @@ export class ExampleDidProvider extends AbstractIdentifierProvider {
       await context.agent.keyManagerDelete({ kid })
     }
     return true
+  }
+
+  async submitTransaction(
+    args: {
+      identifier: IIdentifier
+      txnParams: [
+        attrName: string,
+        attrValue: string,
+        ttl: number,
+        signature: { sigV: number; sigR: string; sigS: string },
+        options: Record<string, any>,
+      ]
+      provider: string
+    },
+    context: IAgentContext<IKeyManager>,
+  ): Promise<any> {
+    throw new Error('FakeDIDProvider submitTransaction not supported yet.')
   }
 
   async addKey(

--- a/packages/test-utils/src/fake-did.ts
+++ b/packages/test-utils/src/fake-did.ts
@@ -66,6 +66,23 @@ export class FakeDidProvider extends AbstractIdentifierProvider {
     return true
   }
 
+  async submitTransaction(
+    args: {
+      identifier: IIdentifier
+      txnParams: [
+        attrName: string,
+        attrValue: string,
+        ttl: number,
+        signature: { sigV: number; sigR: string; sigS: string },
+        options: Record<string, any>,
+      ]
+      provider: string
+    },
+    context: IAgentContext<IKeyManager>,
+  ): Promise<any> {
+    throw new Error('FakeDIDProvider submitTransaction not supported yet.')
+  }
+
   async addKey(
     { identifier, key, options }: { identifier: IIdentifier; key: IKey; options?: any },
     context: IAgentContext<IKeyManager>,


### PR DESCRIPTION
This PR:
- implements a return type on signing a network transaction where flag `signOnly === true`
- otherwise returns the `txnHash`
- implements the associated abstract classes (including placeholders)
- implements the `submitTransaction` method for handling passed to the executor